### PR TITLE
Contact page altered sections

### DIFF
--- a/pages/contact/content.json
+++ b/pages/contact/content.json
@@ -4,7 +4,8 @@
 	"introText": "We’d love to hear your story, so get in touch using our form below and let us know all about your ideas so we can get a bespoke proposal together for you.\n\nAlternatively you can email:\nfreya@thebrandnewstudio.com",
 	"thankYouTitle": "- Thank You -",
 	"thankYouText": "Thanks, we'll be in touch shortly!",
-	"otherContactPostal": "8 Severn Road, Chilton, Didcot, Oxon, OX11 0PW",
-	"otherContactPhone": "077 937 3 88 84",
-	"otherContactText": "Meetings are by appoinment only.\nPlease get in touch if you would like to set up a meeting."
+  "meetingsTitle": "- Meetings -",
+	"meetingsText": "IF YOU ARE INTERESTED IN WORKING WITH BR&NEWWEDDINGS FREYA IS MORE THAN HAPPY TO TRAVEL TO YOU, OR YOU CAN COME TO US HERE IN CHILTON TO CHAT THROUGH YOUR IDEAS.\n\nWE ARE ONLY 45 MINUTES FROM CENTRAL LONDON BY TRAIN, OUR NEAREST STATION IS DIDCOT PARKWAY, AND 10 MINUTES FROM JUNCTION 13 OF THE M4.\n\nAN INITIAL MEETING IS INCLUDED IN THE COST OF YOUR PROPOSAL* (*EITHER IN LONDON OR WITHIN 1 HOURS DRIVE OF THE STUDIO OX11 0PW)\n\nMEETINGS ARE BY APPOINTMENT ONLY.",
+	"contactDetailsTitle": "- Other contact details -",
+	"contactDetailsText": "**PHONE**\n[077 93 73 88 84]('tel:07793738884')\n\n**POSTAL & REGISTERED ADDRESS**\n8 Severn Road, Chilton, Didcot, Oxon, OX11 0PW\n\n**STUDIO ADDRESS**\nBr&newweddings, Office No5, Harwell Innovation Centre, Building 173, Curie Avenue, Harwell, Oxfordshire, OX11 0QG"
 }

--- a/pages/contact/index.jade
+++ b/pages/contact/index.jade
@@ -121,14 +121,13 @@ block main
         .row
           .col-lg-offset-1.col-lg-10
             .text-xs-center
-              h1.text-uppercase - Other Contact Details -
-              p
-                small Our postal address:
-                br
-                =content.otherContactPostal
-              p
-                small Phone:
-                br
-                a(href='tel:#{content.otherContactPhone}')=content.otherContactPhone
-              .text-accent.text-uppercase
-                !=md.render(content.otherContactText)
+              h1.text-uppercase=content.meetingsTitle
+              !=md.render(content.meetingsText)
+    .strip
+      .container
+        .row
+          .col-lg-offset-1.col-lg-10
+            .text-xs-center
+              h1.text-uppercase=content.contactDetailsTitle
+              !=md.render(content.contactDetailsText)
+              


### PR DESCRIPTION
Fixes #7

updates the contact page thus:
# Design

![screen shot 2016-04-26 at 15 58 42](https://cloud.githubusercontent.com/assets/4499581/14822760/c4f7d5b2-0bc7-11e6-9406-f2a3273403aa.jpg)

\* The accent color on the sub heading has been sacrificed in favour of edibility of the content.
# Render

![screen shot 2016-04-26 at 16 00 47](https://cloud.githubusercontent.com/assets/4499581/14822826/09a33ea4-0bc8-11e6-9b79-187d6a8d564e.jpg)
